### PR TITLE
fix: capitalization / param names

### DIFF
--- a/request-config.js
+++ b/request-config.js
@@ -25,5 +25,5 @@ const requestConfig = (marketplaceId, access_token, tempCreds) => {
 		},
 	};
 	
-	return aws4.sign(params, {AccessKeyId, SecretAccessKey, SessionToken});
+	return aws4.sign(params, {accessKeyId: AccessKeyId, secretAccessKey: SecretAccessKey, sessionToken: SessionToken});
 }


### PR DESCRIPTION
`aws4.sign` expects lowercased params. It does not throw if not, but my signature was wrong